### PR TITLE
Initialize on load

### DIFF
--- a/app_espeak.c
+++ b/app_espeak.c
@@ -215,7 +215,7 @@ static int raw_resample(char *fname, double ratio)
 		goto CLEAN3;
 	}
 
-	if ((out_buff = ast_malloc(out_frames*sizeof(float))) == NULL) {
+	if ((out_buff = ast_malloc(out_frames*sizeof(short))) == NULL) {
 		res = -1;
 		goto CLEAN3;
 	}

--- a/app_espeak.c
+++ b/app_espeak.c
@@ -68,7 +68,7 @@ static struct ast_config *cfg;
 static struct ast_flags config_flags = { 0 };
 static const char *cachedir;
 static int usecache;
-static double target_sample_rate;
+static int target_sample_rate;
 static int speed;
 static int volume;
 static int wordgap;
@@ -139,7 +139,7 @@ static int read_config(const char *espeak_conf)
 
 	if (target_sample_rate != 8000 && target_sample_rate != 16000) {
 		ast_log(LOG_WARNING,
-				"eSpeak: Unsupported sample rate: %lf. Falling back to %d\n",
+				"eSpeak: Unsupported sample rate: %d. Falling back to %d\n",
 				target_sample_rate, DEF_RATE);
 		target_sample_rate = DEF_RATE;
 	}
@@ -281,7 +281,7 @@ static int espeak_exec(struct ast_channel *chan, const char *data)
 	}
 
 	ast_debug(1,
-			  "eSpeak:\nText passed: %s\nInterrupt key(s): %s\nLanguage: %s\nRate: %lf\n",
+			  "eSpeak:\nText passed: %s\nInterrupt key(s): %s\nLanguage: %s\nRate: %d\n",
 			  args.text, args.interrupt, voice, target_sample_rate);
 
 	/*Cache mechanism */


### PR DESCRIPTION
Only call `espeak_Initialize()` on module load. This seems to fix https://github.com/zaf/Asterisk-eSpeak/issues/7

I also fixed some minor issues